### PR TITLE
Set minimum length of phone number in Clients app to 4 digits

### DIFF
--- a/src/components/ClientCreation.vue
+++ b/src/components/ClientCreation.vue
@@ -32,7 +32,8 @@
 						v-model="phoneNumber"
 						type="tel"
 						placeholder="Phone Number"
-						pattern="(\+|(\+[1-9])?[0-9].{3,})"
+						minlength="4"
+						pattern="(\+|(\+[1-9])?[0-9]*)"
 						@keyup.enter="submitForm()"
 					/>
 					<input

--- a/src/components/ClientCreation.vue
+++ b/src/components/ClientCreation.vue
@@ -32,7 +32,7 @@
 						v-model="phoneNumber"
 						type="tel"
 						placeholder="Phone Number"
-						pattern="(\+|(\+[1-9])?[0-9]*)"
+						pattern="(\+|(\+[1-9])?[0-9].{3,})"
 						@keyup.enter="submitForm()"
 					/>
 					<input
@@ -104,7 +104,9 @@ export default {
 		},
 		isPhoneValid() {
 			const phoneRegex = /^[0-9 .()\-+,/]*$/g; // eslint-disable-line
-			return phoneRegex.test(this.phoneNumber);
+			return this.phoneNumber.length < 4 && this.phoneNumber.length > 0
+				? false
+				: phoneRegex.test(this.phoneNumber);
 		},
 	},
 	methods: {

--- a/src/components/ClientModal.vue
+++ b/src/components/ClientModal.vue
@@ -53,6 +53,7 @@
 									placeholder="Phone Number"
 									type="tel"
 									class="phone"
+									minlength="4"
 									pattern="(\+|(\+[1-9])?[0-9]*)"
 									@keyup.enter="editClient()"
 								/>
@@ -215,7 +216,10 @@ export default {
 		},
 		isPhoneValid() {
 			const phoneRegex = /^[0-9 .()\-+,/]*$/g; // eslint-disable-line
-			return phoneRegex.test(this.client.phoneNumber);
+			return this.client.phoneNumber.length < 4 &&
+				this.client.phoneNumber.length > 0
+				? false
+				: phoneRegex.test(this.client.phoneNumber);
 		},
 	},
 	async mounted() {


### PR DESCRIPTION
### Changes

Check for minimum of 4 digits on phone fields

## Testing

Create or edit a client and it shouldn't be possible to enter an invalid phone number (only numbers, parentheses, plus and minus symbols, commas and dots should be allowed), or a phone number between 1 and 3 digits 