### PR TITLE
Add new option under Actions in clients table to email client

### DIFF
--- a/img/email-large.svg
+++ b/img/email-large.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="17" viewBox="0 0 20 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.75 1H16.75C17.7125 1 18.5 1.84375 18.5 2.875V14.125C18.5 15.1563 17.7125 16 16.75 16H2.75C1.7875 16 1 15.1563 1 14.125V2.875C1 1.84375 1.7875 1 2.75 1Z" stroke="#010564" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.5 2.87512L9.75 9.43762L1 2.87512" stroke="#010564" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,4 +74,8 @@ main {
 .edit-button {
 	background-image: url("../img/edit.svg");
 }
+
+.email-button {
+	background-image: url("../img/email-large.svg");
+}
 </style>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -43,11 +43,15 @@
 					</td>
 					<td>{{ formatDate(client.lastSession) }}</td>
 					<td>{{ formatDate(client.nextSession) }}</td>
-					<td>
+					<td class="action-buttons">
 						<button
 							class="svg open-button"
 							@click="openClientModal(client.id)"
 						></button>
+						<a
+							class="svg email-button"
+							:href="'mailto:' + client.email"
+						></a>
 						<button
 							class="svg delete-button"
 							@click="deleteClientModal(client)"
@@ -196,5 +200,20 @@ table button {
 
 .delete-button {
 	background-image: url("../../img/trash.svg");
+}
+
+.email-button {
+	-webkit-appearance: button;
+	-moz-appearance: button;
+	appearance: button;
+	text-decoration: none;
+	color: initial;
+	padding: 6px 16px;
+	margin: 3px;
+	width: auto;
+}
+
+.action-buttons {
+	display: flex;
 }
 </style>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -203,11 +203,6 @@ table button {
 }
 
 .email-button {
-	-webkit-appearance: button;
-	-moz-appearance: button;
-	appearance: button;
-	text-decoration: none;
-	color: initial;
 	padding: 6px 16px;
 	margin: 3px;
 	width: auto;

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -216,4 +216,8 @@ table button {
 .action-buttons {
 	display: flex;
 }
+
+.svg {
+	transition: none;
+}
 </style>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -203,7 +203,6 @@ table button {
 }
 
 .email-button {
-	padding: 6px 16px;
 	margin: 3px;
 	width: auto;
 }


### PR DESCRIPTION
### Changes

Adds a new button to send email to clients
Removes transitions from action buttons

### Testing

Click the button and your email client should open with a new email page with the client's address as the recipient

### Screenshot

![image](https://user-images.githubusercontent.com/29747887/198342012-6c5f8db7-f97d-4f41-b5f3-9c63c0fa6beb.png)
