### PR TITLE
Update to NC 24

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
     <website>https://github.com/metaprovide/adminly_clients</website>
     <bugs>https://github.com/metaprovide/adminly_clients</bugs>
     <dependencies>
-        <nextcloud min-version="23" max-version="23"/>
+        <nextcloud min-version="24" max-version="24"/>
     </dependencies>
     <navigations>
       <navigation>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
     <website>https://github.com/metaprovide/adminly_clients</website>
     <bugs>https://github.com/metaprovide/adminly_clients</bugs>
     <dependencies>
-        <nextcloud min-version="24" max-version="24"/>
+        <nextcloud min-version="23" max-version="24"/>
     </dependencies>
     <navigations>
       <navigation>


### PR DESCRIPTION
### Changes

Bumps compatibility with Nextcloud 24

### Testing

After updating the devkit (https://github.com/MetaProvide/adminly_devkit/pull/28) run the setup command from the devkit script
