### PR TITLE
Block changing a client email to other client's e-mail

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -160,12 +160,16 @@ class PageController extends Controller {
 			$client->setContacts($contacts);
 			$client->setPhoneNumber($phoneNumber);
 
-			if ($email) {
-				$oldEmail = $client->getEmail();
-				$client->setEmail(strtolower($email));
-				$this->updateClientSessionsEmail($client, $oldEmail);
-			}
+			$oldEmail = $client->getEmail();
 
+			if ($email && $oldEmail !== $email) {
+				if (!$this->mapper->findByEmail($email, $this->userId)) {
+					$client->setEmail(strtolower($email));
+					$this->updateClientSessionsEmail($client, $oldEmail);
+				} else {
+					return new JSONResponse("Client with email $email already exists", Http::STATUS_BAD_REQUEST);
+				}
+			}
 			return $this->mapper->update($client);
 		} catch (Exception $e) {
 			$this->handleException($e);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -151,14 +151,6 @@ class PageController extends Controller {
 	) {
 		try {
 			$client = $this->mapper->find($id, $this->userId);
-			$client->setName($name);
-			$client->setDescription($description);
-			$client->setTimezone($timezone);
-			$client->setCountry($country);
-			$client->setCity($city);
-			$client->setAge($age);
-			$client->setContacts($contacts);
-			$client->setPhoneNumber($phoneNumber);
 
 			$oldEmail = $client->getEmail();
 
@@ -170,6 +162,17 @@ class PageController extends Controller {
 					return new JSONResponse("Client with email $email already exists", Http::STATUS_BAD_REQUEST);
 				}
 			}
+
+			$client->setName($name);
+			$client->setDescription($description);
+			$client->setTimezone($timezone);
+			$client->setCountry($country);
+			$client->setCity($city);
+			$client->setAge($age);
+			$client->setContacts($contacts);
+			$client->setPhoneNumber($phoneNumber);
+
+
 			return $this->mapper->update($client);
 		} catch (Exception $e) {
 			$this->handleException($e);

--- a/src/components/ClientModal.vue
+++ b/src/components/ClientModal.vue
@@ -166,6 +166,11 @@
 			@toggle-modal="toggleDeleteModal"
 			@update-clients="updateClients"
 		/>
+		<ErrorModal
+			v-if="errorModal"
+			:message="errorMessage"
+			@toggle-modal="toggleErrorModal"
+		/>
 	</div>
 </template>
 
@@ -176,6 +181,7 @@ import { SessionsUtil, ClientsUtil, TimezoneUtil } from "../utils.js";
 import SessionCard from "./SessionCard";
 import ClientDeletion from "./ClientDeletion";
 import TimezonePicker from "@nextcloud/vue/dist/Components/TimezonePicker";
+import ErrorModal from "./ErrorModal";
 
 export default {
 	components: {
@@ -184,13 +190,16 @@ export default {
 		SessionCard,
 		TimezonePicker,
 		ClientDeletion,
+		ErrorModal,
 	},
 	data() {
 		return {
 			sessions: [],
 			editMode: false,
 			deleteModal: false,
+			errorModal: false,
 			client: {},
+			errorMessage: "",
 		};
 	},
 	computed: {
@@ -256,6 +265,9 @@ export default {
 					this.sessions = await SessionsUtil.fetchSessions(
 						this.client.id
 					);
+				} else {
+					this.errorMessage = res.response ? res.response.data : res;
+					this.toggleErrorModal();
 				}
 			}
 		},
@@ -281,6 +293,9 @@ export default {
 			return firstName === lastName
 				? firstName
 				: `${firstName} ${lastName}`;
+		},
+		toggleErrorModal() {
+			this.errorModal = !this.errorModal;
 		},
 	},
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,9 @@ export const ClientsUtil = {
 					throw new Error("Error updating client");
 				return resp;
 			})
-			.catch((err) => console.error(err));
+			.catch((err) => {
+				return err;
+			});
 	},
 	fetchClients: async () => {
 		const url = "/apps/adminly_clients/get";


### PR DESCRIPTION
### Changes

Adds an error modal for displaying a message when trying to update a client's email to an address being used.

### Testing

Create 2 clients:
Client a has an email a@example.com and Client B has an email b@example.com
Try to update Client's B email to a@example.com
An error message will show up because it's already being used.

### Screenshot

![image](https://user-images.githubusercontent.com/29747887/202714862-105aabae-557a-413a-ba9d-c720e0a035d5.png)



