### PR TITLE
Fix clients app not loading

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -334,7 +334,7 @@ class PageController extends Controller {
 		foreach ($events as $event) {
 			$eventData = Reader::read($event["calendardata"]);
 			$dtstart = $eventData->vevent->dtstart->jsonSerialize();
-			$date = new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid));
+			$date = $dtstart[1]->tzid ? new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid)) :  new DateTime($dtstart[3]);
 			$description = $eventData->vevent->description->jsonSerialize()[3];
 
 			$sessions[] = [
@@ -409,7 +409,7 @@ class PageController extends Controller {
 			foreach ($events as $event) {
 				$eventData = Reader::read($event["calendardata"]);
 				$dtstart = $eventData->vevent->dtstart->jsonSerialize();
-				$date = new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid));
+				$date = $dtstart[1]->tzid ? new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid)) :  new DateTime($dtstart[3]);
 
 				$sessionsDates[] = $date->format(DateTime::ISO8601);
 			}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -483,7 +483,7 @@ class PageController extends Controller {
 			foreach ($events as $event) {
 				$eventData = Reader::read($event["calendardata"]);
 				$dtstart = $eventData->vevent->dtstart->jsonSerialize();
-				$date = new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid));
+				$date = $dtstart[1]->tzid ? new DateTime($dtstart[3], new DateTimeZone($dtstart[1]->tzid)) :  new DateTime($dtstart[3]);
 
 				$sessionsDates[] = $date->format(DateTime::ISO8601);
 			}


### PR DESCRIPTION
### Changes 

Adds null checks for timezones in session events 

### Testing

The issue of the table not loading was caused by a client having a session which the event associated with it had no timezone set. I'm not sure how to recreate that scenario but the check added prevents it from happening.
Another way to test it is in the debug, by setting the variable $dtstart[1]->tzid to null.




